### PR TITLE
Added empty container with 120px top margin to navbar

### DIFF
--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -46,3 +46,5 @@
     </div>
   </div>
 </nav>
+
+<div class="container" style="margin-top: 120px"></div>


### PR DESCRIPTION
The navbar was blocking content on all pages so a blank container was added underneath it with a top margin of 120px.